### PR TITLE
Adds provisioning and deprovisioning of http(s) endpoints

### DIFF
--- a/lib/aptly.rb
+++ b/lib/aptly.rb
@@ -9,6 +9,7 @@ require "aptly/database_image"
 require "aptly/operation"
 require "aptly/service"
 require "aptly/version"
+require "aptly/vhost"
 
 require "aptly/client"
 

--- a/lib/aptly/service.rb
+++ b/lib/aptly/service.rb
@@ -7,6 +7,7 @@ module Aptly
     def_attr :container_memory_limit_mb
 
     def_href :operations
+    def_href :vhosts
 
     def scale(container_count: nil, container_memory_limit_mb: nil)
       params = {
@@ -23,6 +24,21 @@ module Aptly
         }
       )
       Operation.new(@access_token, response.parsed)
+    end
+
+    def vhosts
+      @access_token.get(vhosts_href).parsed.
+        dig("_embedded", "vhosts").
+        map { |vhost_data| VHost.new(@access_token, vhost_data) }
+    end
+
+    def create_https_vhost(https_options)
+      response = @access_token.post(
+        vhosts_href,
+        body: https_options.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      VHost.new(@access_token, response.parsed)
     end
   end
 end

--- a/lib/aptly/version.rb
+++ b/lib/aptly/version.rb
@@ -1,3 +1,3 @@
 module Aptly
-  VERSION = "0.0.4".freeze
+  VERSION = "0.0.5".freeze
 end

--- a/lib/aptly/vhost.rb
+++ b/lib/aptly/vhost.rb
@@ -1,0 +1,78 @@
+module Aptly
+  class VHost < Resource
+    def_attr :id
+    def_attr :virtual_domain
+    def_attr :type
+    def_attr :external_host
+    def_attr :internal_host
+    def_attr :status
+    def_attr :default
+    def_attr :internal
+
+    def_href :operations
+
+    def default?
+      default == "true"
+    end
+
+    def internal?
+      internal == "true"
+    end
+
+    def provision!
+      response = @access_token.post(
+        operations_href,
+        body: { type: "provision" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      Operation.new(@access_token, response.parsed)
+    end
+
+    # If you wait_for_completion on the returned Operation,
+    # be prepared to handle a 404 error, which is an indication
+    # of success.
+    def deprovision!
+      response = @access_token.post(
+        operations_href,
+        body: { type: "deprovision" }.to_json,
+        headers: { "Content-Type" => "application/json" }
+      )
+      Operation.new(@access_token, response.parsed)
+    end
+
+    # This code does not handle explicitly provided TLS certs.
+    # They can be added later if we need them.
+    class HttpsOptions
+      def initialize(
+          ip_whitelist: [],
+          container_port: nil,
+          internal: false,
+          default: false,
+          managed_tls_domain: nil
+        )
+        @ip_whitelist = ip_whitelist
+        @container_port = container_port
+        @internal = internal
+        @default = default
+        @managed_tls_domain = managed_tls_domain
+      end
+
+      def to_params
+        {
+          type: "http",
+          platform: "alb",
+          ip_whitelist: @ip_whitelist,
+          container_port: @container_port,
+          internal: !!@internal,
+          default: !!@default,
+          acme: !!@managed_tls_domain,
+          user_domain: @managed_tls_domain
+        }.compact
+      end
+
+      def to_json(*)
+        to_params.to_json
+      end
+    end
+  end
+end

--- a/spec/aptly/vhost_spec.rb
+++ b/spec/aptly/vhost_spec.rb
@@ -1,0 +1,143 @@
+RSpec.describe Aptly::VHost do
+  describe "#id" do
+    it "is the id from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.id).to eq(1)
+    end
+  end
+
+  describe "#virtual_domain" do
+    it "is the virtual domain from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.virtual_domain).to eq("virtual1.example.com")
+    end
+  end
+
+  describe "#type" do
+    it "is the type from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.type).to eq("http_proxy_protocol")
+    end
+  end
+
+  describe "#external_host" do
+    it "is the external host from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.external_host).to eq("external1.example.com")
+    end
+  end
+
+  describe "#internal_host" do
+    it "is the internal host from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.internal_host).to eq("internal1.example.com")
+    end
+  end
+
+  describe "#status" do
+    it "is the status from the JSON data" do
+      vhost = Aptly::VHost.new(nil, vhost_data)
+      expect(vhost.status).to eq("pending")
+    end
+  end
+
+  describe "#default?" do
+    it "is true if this is the default vhost" do
+      default_vhost = Aptly::VHost.new(nil, vhost_data)
+      other_vhost = Aptly::VHost.new(nil, other_vhost_data)
+      expect(default_vhost).to be_default
+      expect(other_vhost).not_to be_default
+    end
+  end
+
+  describe "#internal?" do
+    it "is true if this is an internal vhost" do
+      internal_vhost = Aptly::VHost.new(nil, vhost_data)
+      external_vhost = Aptly::VHost.new(nil, other_vhost_data)
+      expect(internal_vhost).to be_internal
+      expect(external_vhost).not_to be_internal
+    end
+  end
+
+  describe "#provision!" do
+    it "enqueues an Operation to provision the vhost" do
+      access_token = fake_operations_token(type: "provision")
+      vhost = Aptly::VHost.new(access_token, vhost_data)
+      op = vhost.provision!
+      expect(op).to be_a(Aptly::Operation)
+    end
+  end
+
+  describe "#deprovision!" do
+    it "enqueues an Operation to deprovision the vhost" do
+      access_token = fake_operations_token(type: "deprovision")
+      vhost = Aptly::VHost.new(access_token, vhost_data)
+      op = vhost.deprovision!
+      expect(op).to be_a(Aptly::Operation)
+    end
+  end
+
+  def fake_operations_token(body)
+    instance_double("OAuth::AccessToken").tap do |token|
+      allow(token).to receive(:post).with(
+        vhost_data.dig("_links", "operations", "href"),
+        body: body.to_json,
+        headers: { "Content-Type" => "application/json" }
+      ).and_return(
+        instance_double("OAuth::Response", parsed: JsonFixtures.operations.last)
+      )
+    end
+  end
+
+  def vhost_data
+    JsonFixtures.vhosts.first
+  end
+
+  def other_vhost_data
+    JsonFixtures.vhosts.last
+  end
+
+  describe Aptly::VHost::HttpsOptions do
+    describe "#to_params" do
+      it "is a hash suitable for sending to Aptible" do
+        opts = Aptly::VHost::HttpsOptions.new(
+          container_port: 443,
+          internal: true,
+          default: true
+        )
+        expect(opts.to_params).to eq(
+          type: "http",
+          platform: "alb",
+          ip_whitelist: [],
+          container_port: 443,
+          internal: true,
+          default: true,
+          acme: false
+        )
+      end
+
+      it "sets managed TLS options correctly" do
+        opts = Aptly::VHost::HttpsOptions.new(
+          managed_tls_domain: "foo.com"
+        )
+        expect(opts.to_params).to include(
+          acme: true,
+          user_domain: "foo.com"
+        )
+      end
+    end
+
+    describe "#to_json" do
+      it "is a JSON representation of #to_params" do
+        opts = Aptly::VHost::HttpsOptions.new(
+          container_port: 443,
+          internal: true,
+          default: true
+        )
+        params = opts.to_params
+        json = opts.to_json
+        expect(json).to eq(params.to_json)
+      end
+    end
+  end
+end

--- a/spec/support/json_fixtures.rb
+++ b/spec/support/json_fixtures.rb
@@ -122,6 +122,9 @@ module JsonFixtures
         "_links" => {
           "operations" => {
             "href" => "https://example.com/services/1/operations"
+          },
+          "vhosts" => {
+            "href" => "https://example.com/services/1/vhosts"
           }
         }
       },
@@ -134,6 +137,9 @@ module JsonFixtures
         "_links" => {
           "operations" => {
             "href" => "https://example.com/services/2/operations"
+          },
+          "vhosts" => {
+            "href" => "https://example.com/services/2/vhosts"
           }
         }
       }
@@ -170,6 +176,41 @@ module JsonFixtures
         "env" => {
           "VAR1" => "hello",
           "VAR2" => "goodbye"
+        }
+      }
+    ]
+  end
+
+  def self.vhosts
+    [
+      {
+        "id" => 1,
+        "virtual_domain" => "virtual1.example.com",
+        "type" => "http_proxy_protocol",
+        "external_host" => "external1.example.com",
+        "internal_host" => "internal1.example.com",
+        "status" => "pending",
+        "default" => "true",
+        "internal" => "true",
+        "_links" => {
+          "operations" => {
+            "href" => "https://example.com/vhosts/1/operations"
+          }
+        }
+      },
+      {
+        "id" => 2,
+        "virtual_domain" => "virtual2.example.com",
+        "type" => "http_proxy_protocol",
+        "external_host" => "external2.example.com",
+        "internal_host" => "internal2.example.com",
+        "status" => "provisioned",
+        "default" => "false",
+        "internal" => "false",
+        "_links" => {
+          "operations" => {
+            "href" => "https://example.com/vhosts/2/operations"
+          }
         }
       }
     ]


### PR DESCRIPTION
This does not allow provisioning other kinds of endpoints, and it
also does not cover all of the options for provisioning http(s)
endpoints. Specifically, it does not allow you to:
- provide your own certificate
- reuse a certificate that is already in use

both of which are supported by Aptible's API. We can always 
add that functionality later, if we want it.